### PR TITLE
Fix criteria defaulting to local instance in PasswordGeneratorService

### DIFF
--- a/Controllers/PasswordController.cs
+++ b/Controllers/PasswordController.cs
@@ -23,7 +23,7 @@ public class PasswordController : ControllerBase
             return BadRequest("Invalid password length range.");
         }
 
-        var password = _passwordGeneratorService.GeneratePassword();
+        var password = _passwordGeneratorService.GeneratePassword(criteria);
         return Ok(password);
     }
 }

--- a/Services/PasswordGeneratorService.cs
+++ b/Services/PasswordGeneratorService.cs
@@ -5,16 +5,9 @@ namespace PasswordGeneratorAPI.Services;
 
 public class PasswordGeneratorService
 {
-    private readonly PasswordCriteria _passwordCriteria;
-
-    public PasswordGeneratorService(PasswordCriteria passwordCriteria)
+    public string GeneratePassword(PasswordCriteria criteria)
     {
-        this._passwordCriteria = passwordCriteria;
-    }
-    
-    public string GeneratePassword()
-    {
-        int length = _passwordCriteria.GetRandomLength();
+        int length = criteria.GetRandomLength();
         var password = new StringBuilder();
 
         string lowerCaseChars = "abcdefghijklmnopqrstuvwxyz";
@@ -24,7 +17,7 @@ public class PasswordGeneratorService
 
         string allowedChars = string.Empty;
 
-        if (_passwordCriteria.IsMixedCase)
+        if (criteria.IsMixedCase)
         {
             allowedChars += lowerCaseChars + upperCaseChars;
         }
@@ -33,12 +26,12 @@ public class PasswordGeneratorService
             allowedChars += lowerCaseChars;
         }
 
-        if (_passwordCriteria.IsAlphanumeric)
+        if (criteria.IsAlphanumeric)
         {
             allowedChars += numbers;
         }
 
-        if (_passwordCriteria.IncludeSpecialCharacters)
+        if (criteria.IncludeSpecialCharacters)
         {
             allowedChars += specialChars;
         }


### PR DESCRIPTION
Issue was that the program was not using the criteria in the request JSON, instead it would default to whatever is defined within the PasswordCriteria model as default so that has been fixed by passing the criteria into the GeneratePassword method and removing the local instance of _passwordCriteria within the service